### PR TITLE
Dockerfile: install zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.4-cli-alpine
 
 RUN set -ex \
-  && apk --no-cache add bash mysql-dev \
+  && apk --no-cache add bash zip mysql-dev \
   && docker-php-ext-install pdo pdo_mysql
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.4-cli-alpine
 
 RUN set -ex \
   && apk --no-cache add bash zip mysql-dev \
-  && docker-php-ext-install pdo pdo_mysql zip
+  && docker-php-ext-install pdo pdo_mysql
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.4-cli-alpine
 
 RUN set -ex \
   && apk --no-cache add bash zip mysql-dev \
-  && docker-php-ext-install pdo pdo_mysql
+  && docker-php-ext-install pdo pdo_mysql zip
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 


### PR DESCRIPTION
Prevents composer failures like: `Failed to download composer/package-versions-deprecated from dist: The zip extension and unzip/7z commands are both missing, skipping.`. Next fallback is git which is not installed anyway.